### PR TITLE
Limit number of concurrent vector tile requests to 50

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
   "scripts": {
     "build-dev": "rollup -c --environment BUILD:dev",
     "watch-dev": "rollup -c --environment BUILD:dev --watch",
+    "prepare": "npm run build-prod-min && npm run build-css",
     "build-bench": "rollup -c --environment BUILD:bench,MINIFY:true",
     "build-prod": "rollup -c --environment BUILD:production",
     "build-prod-min": "rollup -c --environment BUILD:production,MINIFY:true",

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -29,15 +29,22 @@ export type LoadVectorDataCallback = Callback<LoadVectorTileResult | null | unde
 
 export type AbortVectorData = () => void;
 export type LoadVectorData = (params: RequestedTileParameters, callback: LoadVectorDataCallback) => AbortVectorData | null | undefined;
+export type VectorTileQueueEntry = {key : string,
+    metadata: any,
+    requestFunc: any,
+    callback: LoadVectorDataCallback,
+    cancelled: boolean,
+    cancel: () => void
+};
 
-let requestQueue, numRequests;
+let requestQueue: VectorTileQueueEntry[], numRequests: number;
 const resetRequestQueue = () => {
     requestQueue = [];
     numRequests = 0;
 };
 resetRequestQueue();
 
-const filterQueue = (key) => {
+const filterQueue = (key: string) => {
     for (let i = requestQueue.length - 1; i >= 0; i--) {
         if (requestQueue[i].key === key) {
             requestQueue.splice(i, 1);
@@ -120,7 +127,7 @@ export class DedupedRequest {
                         requestFunc,
                         callback,
                         true
-                    );
+                    ).cancel;
                 } else {
                     filterQueue(key);
                 }

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -116,11 +116,11 @@ export class DedupedRequest {
                 const {key, metadata, requestFunc, callback, cancelled} = request;
                 if (!cancelled) {
                     request.cancel = this.request(
-            key,
-            metadata,
-            requestFunc,
-            callback,
-            true
+                        key,
+                        metadata,
+                        requestFunc,
+                        callback,
+                        true
                     );
                 } else {
                     filterQueue(key);

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -119,7 +119,7 @@ export class DedupedRequest {
             while (requestQueue.size && numRequests < 50) {
                 const request = requestQueue.values().next().value;
                 const {key, metadata, requestFunc, callback, cancelled} = request;
-                requestQueue.delete(key);
+                filterQueue(key);
                 if (!cancelled) {
                     request.cancel = this.request({
                         key,

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -9,7 +9,7 @@ import type {VectorTile} from '@mapbox/vector-tile';
 import type {Callback} from '../types/callback';
 import type {RequestedTileParameters} from './worker_source';
 import type Scheduler from '../util/scheduler';
-import type { Cancelable } from 'src/types/cancelable';
+import type {Cancelable} from 'src/types/cancelable';
 
 export type LoadVectorTileResult = {
     rawData: ArrayBuffer;
@@ -240,7 +240,7 @@ export function loadVectorTile(
         makeRequest,
         callback,
         false
-        );
-    
-        return dedupedAndQueuedRequest.cancel;
+    );
+
+    return dedupedAndQueuedRequest.cancel;
 }


### PR DESCRIPTION
## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [x] Document any changes to public APIs.

This PR limits the number of concurrent vector tile requests that can be made from the map.
We do this by using a request queue, following a pattern already used for raster tiles elsewhere in the codebase. There was some added complexity due to existing code that dedupes the vector tile requests being sent out.

We're also adding an npm `prepare` script so that the git repo can be installed directly with npm, though we could look into pushing to an npm repository too
