### PR TITLE
Add tests for queueing vector tiles

### DIFF
--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -178,14 +178,25 @@ export class DedupedRequest {
                 console.log("actualRequest resolving", err, result);
                 entry.result = [err, result];
 
+                console.log("entry.callbacks", entry.callbacks.size, entry.callbacks);
+
+                for (const cb of entry.callbacks) {
+                    this.addToSchedulerOrCallDirectly({
+                        callback: cb,
+                        metadata,
+                        err,
+                        result,
+                    });
+                }
+
                 // Notable difference here compared to previous deduper, no longer iterating through callbacks stored on the entry
                 // Due to intermittent errors thrown when duplicate arrayBuffers get added to the scheduling
-                this.addToSchedulerOrCallDirectly({
-                    callback,
-                    metadata,
-                    err,
-                    result,
-                });
+                // this.addToSchedulerOrCallDirectly({
+                //     callback,
+                //     metadata,
+                //     err,
+                //     result,
+                // });
 
                 filterQueue(key);
                 advanceImageRequestQueue();

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -175,6 +175,7 @@ export class DedupedRequest {
             numRequests++;
 
             const actualRequestCancel = requestFunc((err, result) => {
+                console.log("actualRequest resolving", err, result);
                 entry.result = [err, result];
 
                 // Notable difference here compared to previous deduper, no longer iterating through callbacks stored on the entry
@@ -197,7 +198,6 @@ export class DedupedRequest {
                 console.log("entry being cancelled");
                 actualRequestCancel();
             };
-            return entry;
         }
 
         return {
@@ -224,6 +224,7 @@ export function loadVectorTile(
 
     const makeRequest = (callback: LoadVectorDataCallback) => {
         const request = getArrayBuffer(params.request, (err?: Error | null, data?: ArrayBuffer | null, cacheControl?: string | null, expires?: string | null) => {
+            console.log("getArrayBuffer callback", err, data);
             if (err) {
                 callback(err);
             } else if (data) {

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -191,9 +191,7 @@ export class DedupedRequest {
                     delete this.entries[key];
                 }, 1000 * 3);
             });
-            entry.cancel = () => {
-                actualRequestCancel();
-            };
+            entry.cancel = actualRequestCancel;
         }
 
         return {
@@ -260,7 +258,5 @@ export function loadVectorTile(
         fromQueue: false
     });
 
-    return () => {
-        dedupedAndQueuedRequest.cancel();
-    };
+    return dedupedAndQueuedRequest.cancel;
 }

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -260,7 +260,6 @@ export function loadVectorTile(
         fromQueue: false
     });
 
-
     return () => {
         dedupedAndQueuedRequest.cancel();
     };

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -97,7 +97,10 @@ export class DedupedRequest {
 
         const removeCallbackFromEntry = ({key, requestCallback}) => {
             const entry = this.getEntry(key);
-            if (entry.result) return;
+            if (entry.result) {
+                console.log("aborting with result");
+                return;
+            }
             entry.callbacks.delete(requestCallback);
             if (entry.callbacks.size) {
                 return;
@@ -191,13 +194,15 @@ export class DedupedRequest {
                 }, 1000 * 3);
             });
             entry.cancel = () => {
-                console.log("entry being cancelled"); actualRequestCancel();
+                console.log("entry being cancelled");
+                actualRequestCancel();
             };
             return entry;
         }
 
         return {
             cancel() {
+                console.log("cancelling from the default return");
                 removeCallbackFromEntry({
                     key,
                     requestCallback: callback,

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -92,6 +92,7 @@ export class DedupedRequest {
     };
 
     request({key, metadata, requestFunc, callback, fromQueue}: DedupedRequestInput): Cancelable {
+        console.log("deduped request");
         const entry = (this.entries[key] = this.getEntry(key));
 
         const removeCallbackFromEntry = ({key, requestCallback}) => {
@@ -189,7 +190,10 @@ export class DedupedRequest {
                     delete this.entries[key];
                 }, 1000 * 3);
             });
-            entry.cancel = actualRequestCancel;
+            entry.cancel = () => {
+                console.log("entry being cancelled"); actualRequestCancel();
+            };
+            return entry;
         }
 
         return {
@@ -227,6 +231,7 @@ export function loadVectorTile(
             }
         });
         return () => {
+            console.log("cancelling makeRequest");
             request.cancel();
             callback();
         };
@@ -246,5 +251,10 @@ export function loadVectorTile(
         fromQueue: false
     });
 
-    return dedupedAndQueuedRequest.cancel;
+    console.log("loadVectorTile returning ", dedupedAndQueuedRequest.cancel);
+
+    return () => {
+        console.log("cancelling loadVectorTile");
+        dedupedAndQueuedRequest.cancel();
+    };
 }

--- a/src/source/load_vector_tile.ts
+++ b/src/source/load_vector_tile.ts
@@ -223,7 +223,7 @@ export class DedupedRequest {
     }
 }
 
-const createArrayBufferCallback = ({requestParams, skipParse}) => {
+const makeArrayBufferHandler = ({requestParams, skipParse}) => {
 
     const makeRequest = (callback: LoadVectorDataCallback) => {
         const request = getArrayBuffer(requestParams, (err?: Error | null, data?: ArrayBuffer | null, cacheControl?: string | null, expires?: string | null) => {
@@ -257,11 +257,11 @@ export function loadVectorTile(
     callback: LoadVectorDataCallback,
     deduped: DedupedRequest,
     skipParse?: boolean,
-    providedArrayBufferCallbackCreator?: any
+    providedArrayBufferHandlerMaker?: any
 ): () => void {
     const key = JSON.stringify(params.request);
 
-    const arrayBufferCallbackMaker = providedArrayBufferCallbackCreator || createArrayBufferCallback;
+    const arrayBufferCallbackMaker = providedArrayBufferHandlerMaker || makeArrayBufferHandler;
     const makeRequest = arrayBufferCallbackMaker({requestParams: params.request, skipParse});
 
     if (params.data) {

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -258,7 +258,7 @@ class VectorTileSource extends Evented implements ISource {
             // if workers are not ready to receive messages yet, use the idle time to preemptively
             // load tiles on the main thread and pass the result instead of requesting a worker to do so
             if (!this.dispatcher.ready) {
-                const cancel = loadVectorTile.call({deduped: this._deduped}, params, (err?: Error | null, data?: LoadVectorTileResult | null) => {
+                const cancel = loadVectorTile.call({}, params, (err?: Error | null, data?: LoadVectorTileResult | null) => {
                     if (err || !data) {
                         done.call(this, err);
                     } else {
@@ -270,7 +270,7 @@ class VectorTileSource extends Evented implements ISource {
                         };
                         if (tile.actor) tile.actor.send('loadTile', params, done.bind(this), undefined, true);
                     }
-                }, true);
+                }, this._deduped, true);
                 tile.request = {cancel};
 
             } else {

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -89,6 +89,10 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
 
             delete this.loading[uid];
 
+            if (workerTile.status === 'done') {
+                return;
+            }
+
             if (aborted || err || !response) {
                 workerTile.status = 'done';
                 if (!aborted) this.loaded[uid] = workerTile;

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -142,7 +142,7 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
 
             this.loaded = this.loaded || {};
             this.loaded[uid] = workerTile;
-        });
+        },this.deduped);
     }
 
     /**

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -74,9 +74,6 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
      */
     loadTile(params: WorkerTileParameters, callback: WorkerTileCallback) {
         const uid = params.uid;
-        console.log("loading tile", uid);
-
-
         const requestParam = params && params.request;
         const perf = requestParam && requestParam.collectResourceTiming;
 
@@ -84,9 +81,6 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
         workerTile.abort = this.loadVectorData(params, (err, response) => {
 
             const aborted = !this.loading[uid];
-
-            console.log("loadVectorData resolving", "aborted", aborted, "\nerr", err, "\nresponse", response);
-
             delete this.loading[uid];
 
             if (workerTile.status === 'done') {
@@ -194,14 +188,10 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
      */
     abortTile(params: TileParameters, callback: WorkerTileCallback) {
         const uid = params.uid;
-        console.log("aborting tile", uid);
-
         const tile = this.loading[uid];
         if (tile) {
-            console.log("tile found, aborting it");
             if (tile.abort) tile.abort();
             delete this.loading[uid];
-            console.log("tile aborted", this.loading);
         }
         callback();
     }

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -85,7 +85,7 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
 
             const aborted = !this.loading[uid];
 
-            console.log("loadVectorData resolving", this.loading, aborted);
+            console.log("loadVectorData resolving", "aborted", aborted, "\nerr", err, "\nresponse", response);
 
             delete this.loading[uid];
 

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -136,7 +136,7 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
 
             this.loaded = this.loaded || {};
             this.loaded[uid] = workerTile;
-        },this.deduped);
+        }, this.deduped);
     }
 
     /**

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -74,6 +74,8 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
      */
     loadTile(params: WorkerTileParameters, callback: WorkerTileCallback) {
         const uid = params.uid;
+        console.log("loading tile", uid);
+
 
         const requestParam = params && params.request;
         const perf = requestParam && requestParam.collectResourceTiming;
@@ -82,6 +84,8 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
         workerTile.abort = this.loadVectorData(params, (err, response) => {
 
             const aborted = !this.loading[uid];
+
+            console.log("loadVectorData resolving", this.loading, aborted);
 
             delete this.loading[uid];
 
@@ -186,10 +190,14 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
      */
     abortTile(params: TileParameters, callback: WorkerTileCallback) {
         const uid = params.uid;
+        console.log("aborting tile", uid);
+
         const tile = this.loading[uid];
         if (tile) {
+            console.log("tile found, aborting it");
             if (tile.abort) tile.abort();
             delete this.loading[uid];
+            console.log("tile aborted", this.loading);
         }
         callback();
     }

--- a/test/unit/source/load_vector_tile.test.ts
+++ b/test/unit/source/load_vector_tile.test.ts
@@ -6,12 +6,17 @@ import {loadVectorTile, DedupedRequest} from '../../../src/source/load_vector_ti
 
 const scheduler = {add: () => {}};
 
-test('loadVectorTile does not resolve duplicate requests', () => {
+test('loadVectorTile does not make array buffer request for duplicate tile requests', () => {
     const deduped = new DedupedRequest(scheduler);
     const params = {url: 'http://localhost:2900/fake.pbf'};
-    loadVectorTile(params, () => {}, deduped, false, () => { return () => {}; });
+    expect.assertions(1);
+    const arrayBufRequester = () => () => {
+        expect(true).toBeTruthy();
+    };
+    loadVectorTile(params, () => {}, deduped, false, arrayBufRequester);
+    loadVectorTile(params, () => {}, deduped, false, arrayBufRequester);
+    loadVectorTile(params, () => {}, deduped, false, arrayBufRequester);
 });
 
-// does not resolve duplicated requests
 // Handles 300 concurrent requests through queue
 // Fails to fetch if concurrent requests get too large when unqueued

--- a/test/unit/source/load_vector_tile.test.ts
+++ b/test/unit/source/load_vector_tile.test.ts
@@ -34,15 +34,18 @@ beforeEach(() => {
 });
 
 test('loadVectorTile does not make array buffer request for duplicate tile requests', () => {
+    vi.useFakeTimers();
     const deduped = new DedupedRequest(createScheduler());
     const params = {request: {url: 'http://localhost:2900/fake.pbf'}} as RequestedTileParameters;
-    expect.assertions(1);
-    const arrayBufRequester = () => () => {
-        expect(true).toBeTruthy();
-    };
-    loadVectorTile(params, () => {}, deduped, false, arrayBufRequester);
-    loadVectorTile(params, () => {}, deduped, false, arrayBufRequester);
-    loadVectorTile(params, () => {}, deduped, false, arrayBufRequester);
+
+    loadVectorTile(params, () => {}, deduped, false, cancellableDelayedArrayBufRequestMaker);
+    loadVectorTile(params, () => {}, deduped, false, cancellableDelayedArrayBufRequestMaker);
+    loadVectorTile(params, () => {}, deduped, false, cancellableDelayedArrayBufRequestMaker);
+
+    vi.advanceTimersByTime(arrayBufDelay);
+    expect(arrayBufResolutionSpy).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+
 });
 
 test('only processes concurrent requests up to the queue limit', () => {

--- a/test/unit/source/load_vector_tile.test.ts
+++ b/test/unit/source/load_vector_tile.test.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import {test, expect, vi} from '../../util/vitest';
+// eslint-disable-next-line import/no-unresolved
+import rawTileData from '../../fixtures/mbsv5-6-18-23.vector.pbf?arraybuffer';
+import {loadVectorTile, DedupedRequest} from '../../../src/source/load_vector_tile';
+
+const scheduler = {add: () => {}};
+
+test('loadVectorTile does not resolve duplicate requests', () => {
+    const deduped = new DedupedRequest(scheduler);
+    const params = {url: 'http://localhost:2900/fake.pbf'};
+    loadVectorTile(params, () => {}, deduped, false, () => { return () => {}; });
+});
+
+// does not resolve duplicated requests
+// Handles 300 concurrent requests through queue
+// Fails to fetch if concurrent requests get too large when unqueued

--- a/test/unit/source/load_vector_tile.test.ts
+++ b/test/unit/source/load_vector_tile.test.ts
@@ -8,7 +8,7 @@ const scheduler = {add: () => {}};
 
 test('loadVectorTile does not make array buffer request for duplicate tile requests', () => {
     const deduped = new DedupedRequest(scheduler);
-    const params = {url: 'http://localhost:2900/fake.pbf'};
+    const params = {request: {url: 'http://localhost:2900/fake.pbf'}};
     expect.assertions(1);
     const arrayBufRequester = () => () => {
         expect(true).toBeTruthy();
@@ -19,4 +19,24 @@ test('loadVectorTile does not make array buffer request for duplicate tile reque
 });
 
 // Handles 300 concurrent requests through queue
+
+test('only processes concurrent requests up to the queue limit', () => {
+    vi.useFakeTimers();
+    const deduped = new DedupedRequest(scheduler);
+    expect.assertions(49);
+    const arrayBufRequester = () => {
+        return () => {
+            setTimeout(() => {
+                expect(true).toBeTruthy();
+            }, 1500);
+        };
+    };
+
+    for (let i = 0; i < 300; i++) {
+        loadVectorTile({request: {url: i}}, () => {}, deduped, false, arrayBufRequester);
+    }
+    vi.advanceTimersByTime(1500);
+    vi.useRealTimers();
+});
 // Fails to fetch if concurrent requests get too large when unqueued
+// Some stuff about cancelling within the queue?

--- a/test/unit/source/vector_tile_worker_source.test.ts
+++ b/test/unit/source/vector_tile_worker_source.test.ts
@@ -11,7 +11,7 @@ import rawTileData from '../../fixtures/mbsv5-6-18-23.vector.pbf?arraybuffer';
 
 const actor = {send: () => {}};
 
-test('VectorTileWorkerSource#abortTile aborts pending request', () => {
+test.only('VectorTileWorkerSource#abortTile aborts pending request', () => {
     const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
 
     expect.assertions(3);

--- a/test/unit/source/vector_tile_worker_source.test.ts
+++ b/test/unit/source/vector_tile_worker_source.test.ts
@@ -11,7 +11,7 @@ import rawTileData from '../../fixtures/mbsv5-6-18-23.vector.pbf?arraybuffer';
 
 const actor = {send: () => {}};
 
-test.only('VectorTileWorkerSource#abortTile aborts pending request', () => {
+test('VectorTileWorkerSource#abortTile aborts pending request', () => {
     const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
 
     expect.assertions(3);


### PR DESCRIPTION
## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [x] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.

## Context

- This PR adds unit tests for the queueing functionality and for existing deduping functionality on vector tile requests.
- It also returns to calling all callbacks for a deduped tile entry to ensure that tile aborting tests pass. 
    - We now check inside the resolution within the worker tile source whether the tile is `done` to avoid previous issues where we'd try to process the same array buffer twice
- It also refactors a couple of functions to allow for dependency injections in the tests